### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod +x /action/entrypoint.sh
 
 ENTRYPOINT ["/action/entrypoint.sh"]
 
-#RUN wget https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.4.2/phpcs.phar -O phpcs \
+#RUN wget https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/download/3.4.2/phpcs.phar -O phpcs \
 #    && chmod a+x phpcs \
 #    && mv phpcs /usr/local/bin/phpcs
 

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ You can set YNA standard as default:
 then
 `phpcs /path/to/php/class.php`
 
-For more usage cases check [official documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki "Title")
+For more usage cases check [official documentation](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki "Title")
 
 ### Use CodeSniffer in PHPStorm
 - `Preferences -> Languages & Frameworks -> PHP -> Quality tools -> Code Sniffer`


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932